### PR TITLE
Drop setuptools from install_requires

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"
-rm -rf build dist syncing.egg-info
+rm -vrf ./build/* ./dist/* ./*.pyc ./*.tgz ./*.egg-info
 export ENABLE_SETUP_LONG_DESCRIPTION="TRUE"
 python setup.py sdist bdist_wheel -v
 

--- a/setup.py
+++ b/setup.py
@@ -152,5 +152,4 @@ if __name__ == '__main__':
         extras_require=extras,
         tests_require=['nose>=1.0', 'ddt'],
         test_suite='nose.collector',
-        setup_requires=['nose>=1.0'],
     )

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
     extras['all'] = sorted(functools.reduce(set.union, extras.values(), set()))
     extras['dev'] = extras['all'] + [
         'wheel', 'sphinx', 'gitchangelog', 'mako', 'sphinx_rtd_theme',
-        'setuptools>=36.0.1', 'sphinxcontrib-restbuilder', 'nose', 'coveralls',
+        'sphinxcontrib-restbuilder', 'nose', 'coveralls',
         'ddt', 'sphinx-click', 'matplotlib'
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,6 @@ if __name__ == '__main__':
             ],
         },
         extras_require=extras,
-        tests_require=['nose>=1.0', 'ddt'],
+        tests_require=['nose>=1.0', 'ddt', 'dill', 'matplotlib'],
         test_suite='nose.collector',
     )


### PR DESCRIPTION
Specifying the version of `setuptools` in the `setup.py` script does not work, since `setuptools` needs to be already installed to run the file (due to `import setuptools` at the top of the script).
Besides, i think the project has no runtime dependency on setuptools, such as `pkg_resources`, correct?